### PR TITLE
 Change MakeSafe to MarkSafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ composer require pattern-lab/pattern-lab-safe-data
 You can mark data as safe in your json or yml data files by using this format: 
 
 ```
-"key": "MakeSafe() > This will <em>not</em> get escaped."
+"key": "MarkSafe() > This will <em>not</em> get escaped."
 ```
 
 ## Disabling the Plugin

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   },
   "require": {
-    "php": "^7",
+    "php": "^7.1",
     "pattern-lab/core": "^2.9",
     "twig/twig": "^1"
   },

--- a/src/PatternLabListener.php
+++ b/src/PatternLabListener.php
@@ -9,8 +9,6 @@ use PatternLab\Listener;
 /**
  * Provides a Pattern Lab listener to prevent data values from being escaped.
  *
- * @todo Add tests.
- * @todo Try with PSR-4.
  * @todo Only match on 'MakeSafe() >' and share the prefix.
  * @todo Change from MakeSafe to MarkSafe - this doesn't transform anything.
  */

--- a/src/PatternLabListener.php
+++ b/src/PatternLabListener.php
@@ -9,7 +9,6 @@ use PatternLab\Listener;
 /**
  * Provides a Pattern Lab listener to prevent data values from being escaped.
  *
- * @todo Only match on 'MakeSafe() >' and share the prefix.
  * @todo Change from MakeSafe to MarkSafe - this doesn't transform anything.
  */
 class PatternLabListener extends Listener {
@@ -18,6 +17,11 @@ class PatternLabListener extends Listener {
    * The plugin's name in the Pattern Lab configuration and composer.json.
    */
   const PLUGIN_NAME = 'safeData';
+
+  /**
+   * The prefix used to indicate a value should be marked safe.
+   */
+  protected const PREFIX = 'MakeSafe() > ';
 
   /**
    * Create the listener and subscribe it to the data loaded event.
@@ -44,10 +48,8 @@ class PatternLabListener extends Listener {
     $data = Data::get();
     array_walk_recursive($data, function (&$value) use ($charset) {
       $matches = [];
-      if (preg_match('/^MakeSafe\((.*)\)$/ms', $value, $matches)) {
-        $value = new \Twig_Markup($matches[1], $charset);
-      }
-      elseif (preg_match('/^MakeSafe\(\)\s*>(.*)$/ms', $value, $matches)) {
+      $prefix = preg_quote(static::PREFIX, '/');
+      if (preg_match('/^' . $prefix . '(.*)$/ms', $value, $matches)) {
         $value = new \Twig_Markup(ltrim($matches[1]), $charset);
       }
     });
@@ -66,6 +68,19 @@ class PatternLabListener extends Listener {
    */
   protected function getConfig($name) {
     return Config::getOption('plugins.' . static::PLUGIN_NAME . ".$name");
+  }
+
+  /**
+   * Update a data value to be marked as safe.
+   *
+   * @param string $value
+   *   The value to be marked safe.
+   *
+   * @return string
+   *   The updated value.
+   */
+  public static function markSafe($value) {
+    return static::PREFIX . $value;
   }
 
 }

--- a/tests/PatternLabListenerTest.php
+++ b/tests/PatternLabListenerTest.php
@@ -11,8 +11,6 @@ use PHPUnit\Framework\TestCase;
  * Test the safe data pattern lab listener.
  *
  * @group SafeData
- *
- * @todo Test newline chomping after `>`.
  */
 class PatternLabListenerTest extends TestCase {
 
@@ -45,8 +43,10 @@ class PatternLabListenerTest extends TestCase {
 
   /**
    * Test marking data values as safe.
+   *
+   * @dataProvider provideSafeStrings()
    */
-  public function testProcessSafeData() {
+  public function testProcessSafeData($raw_value, $content) {
     Config::setOption('plugins.safeData.enabled', true);
     Data::setOption('safe', 'MakeSafe() > value');
 
@@ -102,7 +102,21 @@ class PatternLabListenerTest extends TestCase {
   }
 
   /**
+   * Provide raw data values for processing and the expected processed output.
+   *
+   * @return \Generator
+   *
+   * @see \FabbDev\SafeData\Tests\PatternLabListenerTest::testProcessSafeData()
+   */
+  public function provideSafeStrings() {
+    yield ['MakeSafe() > value', 'value'];
+    yield ["MakeSafe() >\n value", 'value'];
+  }
+
+  /**
    * Provide UTF-8 strings with character lengths to test the 'charset' option.
+   *
+   * @see \FabbDev\SafeData\Tests\PatternLabListenerTest::testCharacterSet()
    */
   public function provideCharacterSetStrings() {
     yield ['Iñtërnâtiônàlizætiøn', 20];


### PR DESCRIPTION
- Remove support for `MakeSafe(value)` (simpler to have just the one to support).
- Change `MakeSafe` to `MarkSafe`: Hopefully this emphasises that it doesn't modify data, it prevents data from being escaped.
- Factor the prefix into a constant and method.
- Fix a bug in multiline handling.
